### PR TITLE
Send quit command to ipython

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ Run previous command.
 
 Restart IPython.
 
+    :IPythonCellPDBQuit
+
+Send quit command which will quit the debugger if running.
+
 [vim-slime]: https://github.com/jpalardy/vim-slime
 
 
@@ -359,6 +363,9 @@ nnoremap <Leader>p :IPythonCellPrevCommand<CR>
 
 " map <Leader>q to restart ipython
 nnoremap <Leader>q :IPythonCellRestart<CR>
+
+" map <Leader>e to send quit command
+nnoremap <Leader>e :IPythonCellPDBQuit<CR>
 
 ~~~
 

--- a/plugin/ipython-cell.vim
+++ b/plugin/ipython-cell.vim
@@ -72,6 +72,10 @@ function! IPythonCellRestart()
     exec s:python_command "ipython_cell.restart_ipython()"
 endfunction
 
+function! IPythonCellPDBQuit()
+    exec s:python_command "ipython_cell.quit()"
+endfunction
+
 function! IPythonCellRun(...)
     exec s:python_command "ipython_cell.run('" . join(a:000, ',') . "')"
 endfunction
@@ -86,5 +90,6 @@ command! -nargs=0 IPythonCellNextCell call IPythonCellNextCell()
 command! -nargs=0 IPythonCellPrevCell call IPythonCellPrevCell()
 command! -nargs=0 IPythonCellPrevCommand call IPythonCellPrevCommand()
 command! -nargs=0 IPythonCellRestart call IPythonCellRestart()
+command! -nargs=0 IPythonCellPDBQuit call IPythonCellPDBQuit()
 command! -nargs=0 IPythonCellRun call IPythonCellRun()
 command! -nargs=0 IPythonCellRunTime call IPythonCellRun('-t')

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -107,6 +107,11 @@ def clear():
     _slimesend("%clear")
 
 
+def quit():
+    """Send quit to exit debugger."""
+    _slimesend("quit")
+
+
 def close_all():
     """Close all figure windows."""
     _slimesend("plt.close('all')")


### PR DESCRIPTION
Used for quitting the debugger. Resolves #8.

All tests are passing locally:

(base) [@6700 ~/source/vim-ipython-cell/test] (master) $ python -m unittest test_ipython_cell.py -vvv
warning: importing ipython_cell outside vim, some functions will not work
test_get_current_cell_boundaries_cursor_end_of_cell (test_ipython_cell.TestIPythonCell) ... ok
test_get_current_cell_boundaries_cursor_end_of_file (test_ipython_cell.TestIPythonCell) ... ok
test_get_current_cell_boundaries_cursor_first_cell (test_ipython_cell.TestIPythonCell) ... ok
test_get_current_cell_boundaries_cursor_last_cell (test_ipython_cell.TestIPythonCell) ... ok
test_get_current_cell_boundaries_cursor_middle_of_cell (test_ipython_cell.TestIPythonCell) ... ok
test_get_current_cell_boundaries_cursor_start_of_cell (test_ipython_cell.TestIPythonCell) ... ok
test_get_current_cell_boundaries_cursor_start_of_file (test_ipython_cell.TestIPythonCell) ... ok
test_get_next_cell_cursor_end_of_cell (test_ipython_cell.TestIPythonCell) ... ok
test_get_next_cell_cursor_middle_of_cell (test_ipython_cell.TestIPythonCell) ... ok
test_get_next_cell_cursor_start_of_cell (test_ipython_cell.TestIPythonCell) ... ok
test_get_prev_cell_cursor_end_of_cell (test_ipython_cell.TestIPythonCell) ... ok
test_get_prev_cell_cursor_middle_of_cell (test_ipython_cell.TestIPythonCell) ... ok
test_get_prev_cell_cursor_start_of_cell (test_ipython_cell.TestIPythonCell) ... ok
test_get_rows_with_marks (test_ipython_cell.TestIPythonCell) ... ok
test_get_rows_with_marks_multiple_rows (test_ipython_cell.TestIPythonCell) ... ok
test_get_rows_with_tag (test_ipython_cell.TestIPythonCell) ... ok
test_get_rows_with_tag_multiple_rows (test_ipython_cell.TestIPythonCell) ... ok

----------------------------------------------------------------------
Ran 17 tests in 0.001s
