### PR TITLE
Enclose filepath in single quotes for paths with spaces

### DIFF
--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -113,7 +113,7 @@ def run(*args):
     options = " ".join(args)
     run_command = vim.eval('g:ipython_cell_run_command')
     run_command = run_command.format(options=options,
-                                     filepath=vim.current.buffer.name)
+                                     filepath=(r"'{}'").format(vim.current.buffer.name))
     _slimesend(run_command)
 
 


### PR DESCRIPTION
I encountered an issue with `IPythonCellRun` where a path with spaces in is not escaped or enclosed, leading to the REPL attempting to run an invalid path - the first space break.

Although I try to avoid paths with spaces in, Dropbox Business/Personal insists in separating the names with a space. 

This pull request simply encloses the vim buffer name and tells Python it's a raw string. Fixes the problem and I think is non-breaking.