### PR TITLE
Adding EditLine and EditRegion commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,10 +344,10 @@ xmap <Leader>h <Plug>SlimeRegionSend
 " map <Leader>p to run the previous command
 nnoremap <Leader>p :IPythonCellPrevCommand<CR>
 
-" map <Leader>e to send current line for editing
+" map <Leader>e to send current line for editing in normal mode
 nnoremap <Leader>e :IPythonCellEditLine<CR>
 
-" map <Leader>e to send current selection for editing
+" map <Leader>e to send current selection for editing in visual mode
 vnoremap <Leader>e :<C-U>IPythonCellEditRegion<CR>
 
 " map <Leader>Q to restart ipython

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ contains sensitive data.
 | `:IPythonCellPrevCell`                | Jump to the previous cell header                                                            |
 | `:IPythonCellNextCell`                | Jump to the next cell header                                                                |
 | `:IPythonCellPrevCommand`             | Run previous command                                                                        |
+| `:IPythonCellEditLine`                | Send current line without executing it for editing                                          |
+| `:IPythonCellEditRegion`              | Send selected region without executing it for editing                                       |
+| `:IPythonCellPrevCommand`             | Run previous command                                                                        |
 | `:IPythonCellRestart`                 | Restart IPython                                                                             |
 
 <sup>1</sup> Can be [configured for other REPLs](#other-repls).  
@@ -340,6 +343,12 @@ xmap <Leader>h <Plug>SlimeRegionSend
 
 " map <Leader>p to run the previous command
 nnoremap <Leader>p :IPythonCellPrevCommand<CR>
+
+" map <Leader>e to send current line for editing
+nnoremap <Leader>e :IPythonCellEditLine<CR>
+
+" map <Leader>e to send current selection for editing
+vnoremap <Leader>e :<C-U>IPythonCellEditRegion<CR>
 
 " map <Leader>Q to restart ipython
 nnoremap <Leader>Q :IPythonCellRestart<CR>

--- a/plugin/ipython-cell.vim
+++ b/plugin/ipython-cell.vim
@@ -118,3 +118,40 @@ augroup highlight_python_cells
     autocmd!
     autocmd BufEnter,BufWinEnter,WinEnter * call UpdateCellHighlight()
 augroup END
+
+function! VisualSelection()
+    " By DarkWiiPlayer 2017 https://stackoverflow.com/a/47051271
+    if mode()=="v"
+        let [line_start, column_start] = getpos("v")[1:2]
+        let [line_end, column_end] = getpos(".")[1:2]
+    else
+        let [line_start, column_start] = getpos("'<")[1:2]
+        let [line_end, column_end] = getpos("'>")[1:2]
+    end
+    if (line2byte(line_start)+column_start) > (line2byte(line_end)+column_end)
+        let [line_start, column_start, line_end, column_end] =
+        \   [line_end, column_end, line_start, column_start]
+    end
+    let lines = getline(line_start, line_end)
+    if len(lines) == 0
+            return ''
+    endif
+    let lines[-1] = lines[-1][: column_end - 1]
+    let lines[0] = lines[0][column_start - 1:]
+    return lines
+endfunction
+
+function! IPythonCellEditLine()
+    execute 'SlimeSend0 "' . getline(".") . '"'
+endfunc
+
+function! IPythonCellEditRegion()
+    let lines=VisualSelection()
+    for line in lines[0:-2]
+        execute 'SlimeSend0 "' . line . '\n"'
+    endfor
+    execute 'SlimeSend0 "' . lines[-1] . '"'
+endfunc
+
+command! -nargs=0 IPythonCellEditLine call IPythonCellEditLine()
+command! -nargs=0 IPythonCellEditRegion call IPythonCellEditRegion()


### PR DESCRIPTION
I've added two commands that allow the user to edit the sent code before executing it. Here's a short demo:

![vim-edit-region](https://user-images.githubusercontent.com/15214418/116162185-914ef000-a6f5-11eb-9404-86350331648c.gif)

This could be useful for adapting code that can not be executed in its original form, e.g. by deleting `self.` within class methods that reference attributes, so that they can be provided in IPython. 
