### PR TITLE
Add insert cell above and insert cell below commands

### DIFF
--- a/plugin/ipython-cell.vim
+++ b/plugin/ipython-cell.vim
@@ -14,7 +14,7 @@ endif
 
 let g:ipython_cell_delimit_cells_by = get(g:, 'ipython_cell_delimit_cells_by', 'tags')
 let g:ipython_cell_tag = get(g:, 'ipython_cell_tag', ['# %%', '#%%', '# <codecell>', '##'])
-let g:ipython_insert_cell_tag = get(g:, 'ipython_insert_cell_tag', g:ipython_cell_tag[0])
+let g:ipython_cell_insert_tag = get(g:, 'ipython_cell_insert_tag', g:ipython_cell_tag[0])
 let g:ipython_cell_regex = get(g:, 'ipython_cell_regex', 0)
 let g:ipython_cell_valid_marks = get(g:, 'ipython_cell_valid_marks', 'abcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
 let g:ipython_cell_run_command = get(g:, 'ipython_cell_run_command', '%run {options} "{filepath}"')
@@ -84,11 +84,11 @@ function! IPythonCellRun(...)
     exec s:python_command "ipython_cell.run('" . join(a:000, ',') . "')"
 endfunction
 
-function! IPythonInsertCellBelow(...)
+function! IPythonCellInsertBelow(...)
     exec s:python_command "ipython_cell.insert_cell_below()"
 endfunction
 
-function! IPythonInsertCellAbove(...)
+function! IPythonCellInsertAbove(...)
     exec s:python_command "ipython_cell.insert_cell_above()"
 endfunction
 
@@ -104,8 +104,8 @@ command! -nargs=0 IPythonCellPrevCommand call IPythonCellPrevCommand()
 command! -nargs=0 IPythonCellRestart call IPythonCellRestart()
 command! -nargs=0 IPythonCellRun call IPythonCellRun()
 command! -nargs=0 IPythonCellRunTime call IPythonCellRun('-t')
-command! -nargs=0 IPythonInsertCellBelow call IPythonInsertCellBelow()
-command! -nargs=0 IPythonInsertCellAbove call IPythonInsertCellAbove()
+command! -nargs=0 IPythonCellInsertBelow call IPythonCellInsertBelow()
+command! -nargs=0 IPythonCellInsertAbove call IPythonCellInsertAbove()
 
 highlight default link IPythonCell Folded
 function! UpdateCellHighlight()

--- a/plugin/ipython-cell.vim
+++ b/plugin/ipython-cell.vim
@@ -14,7 +14,7 @@ endif
 
 let g:ipython_cell_delimit_cells_by = get(g:, 'ipython_cell_delimit_cells_by', 'tags')
 let g:ipython_cell_tag = get(g:, 'ipython_cell_tag', ['# %%', '#%%', '# <codecell>', '##'])
-let g:ipython_cell_insert_tag = get(g:, 'ipython_cell_insert_tag', g:ipython_cell_tag[0])
+let g:ipython_cell_insert_tag = get(g:, 'ipython_cell_insert_tag', '# %% ')
 let g:ipython_cell_regex = get(g:, 'ipython_cell_regex', 0)
 let g:ipython_cell_valid_marks = get(g:, 'ipython_cell_valid_marks', 'abcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
 let g:ipython_cell_run_command = get(g:, 'ipython_cell_run_command', '%run {options} "{filepath}"')

--- a/plugin/ipython-cell.vim
+++ b/plugin/ipython-cell.vim
@@ -14,6 +14,7 @@ endif
 
 let g:ipython_cell_delimit_cells_by = get(g:, 'ipython_cell_delimit_cells_by', 'tags')
 let g:ipython_cell_tag = get(g:, 'ipython_cell_tag', ['# %%', '#%%', '# <codecell>', '##'])
+let g:ipython_insert_cell_tag = get(g:, 'ipython_insert_cell_tag', g:ipython_cell_tag[0])
 let g:ipython_cell_regex = get(g:, 'ipython_cell_regex', 0)
 let g:ipython_cell_valid_marks = get(g:, 'ipython_cell_valid_marks', 'abcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
 let g:ipython_cell_run_command = get(g:, 'ipython_cell_run_command', '%run {options} "{filepath}"')
@@ -83,6 +84,14 @@ function! IPythonCellRun(...)
     exec s:python_command "ipython_cell.run('" . join(a:000, ',') . "')"
 endfunction
 
+function! IPythonInsertCellBelow(...)
+    exec s:python_command "ipython_cell.insert_cell_below()"
+endfunction
+
+function! IPythonInsertCellAbove(...)
+    exec s:python_command "ipython_cell.insert_cell_above()"
+endfunction
+
 command! -nargs=0 IPythonCellClear call IPythonCellClear()
 command! -nargs=0 IPythonCellClose call IPythonCellClose()
 command! -nargs=0 IPythonCellExecuteCell call IPythonCellExecuteCell()
@@ -95,6 +104,8 @@ command! -nargs=0 IPythonCellPrevCommand call IPythonCellPrevCommand()
 command! -nargs=0 IPythonCellRestart call IPythonCellRestart()
 command! -nargs=0 IPythonCellRun call IPythonCellRun()
 command! -nargs=0 IPythonCellRunTime call IPythonCellRun('-t')
+command! -nargs=0 IPythonInsertCellBelow call IPythonInsertCellBelow()
+command! -nargs=0 IPythonInsertCellAbove call IPythonInsertCellAbove()
 
 highlight default link IPythonCell Folded
 function! UpdateCellHighlight()

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -147,7 +147,7 @@ def insert_cell_below():
 def insert_cell_above():
     insert_tag = vim.eval('g:ipython_insert_cell_tag')
 
-    current_row, _ = vim.window.cursor
+    current_row, _ = vim.current.window.cursor
     cell_boundaries = _get_cell_boundaries()
     start_row, _ = _get_current_cell_boundaries(current_row, cell_boundaries)
 
@@ -158,7 +158,7 @@ def insert_cell_above():
     vim.command("normal!O")
     vim.command("normal!O")
     vim.command("normal!i" + insert_tag)
-    current_row, _ = vim.window.cursor
+    current_row, _ = vim.current.window.cursor
     if current_row != 1:
         vim.command("normal!o")
     else:

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -170,10 +170,10 @@ def insert_cell_above():
     if start_row == 1 and not first_line_contains_cell_header:
         vim.command("normal!O")
         vim.command("normal!i" + insert_tag)
-
-    vim.command("normal!O")
-    vim.command("normal!O")
-    vim.command("normal!i" + insert_tag)
+    else:
+        vim.command("normal!O")
+        vim.command("normal!O")
+        vim.command("normal!i" + insert_tag)
 
 
 def previous_command():

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -154,7 +154,11 @@ def insert_cell_above():
     # If the cursor not at the header of the current cell,
     # we move the cursor to the header
     if current_row != start_row:
-        jump_prev_cell()
+        try:
+            vim.current.window.cursor = (start_row, 0)
+        except vim.error:
+            vim.command("echo 'Cell header is outside the buffer boundaries'")
+
     vim.command("normal!O")
     vim.command("normal!O")
     vim.command("normal!i" + insert_tag)

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -116,6 +116,51 @@ def jump_prev_cell():
             vim.command("echo 'Cell header is outside the buffer boundaries'")
 
 
+def insert_cell_below():
+    current_row, _ = vim.current.window.cursor
+    cell_boundaries = _get_cell_boundaries()
+    _, end_row = _get_current_cell_boundaries(current_row,
+                                                      cell_boundaries)
+
+    # Required for Python 2
+    if end_row is None:
+        end_row = len(vim.current.buffer)
+
+    # Jump cursor to end_row
+    if end_row != current_row:
+        try:
+            vim.current.window.cursor = (end_row, 0)
+        except vim.error:
+            vim.command("echo 'Cell header is outside the buffer boundaries'")
+
+    # Insert tag bellow
+    insert_tag = vim.eval('g:ipython_insert_cell_tag')
+    vim.command("normal!o")
+    vim.command("normal!o" + insert_tag)
+    vim.command("normal!o")
+
+
+def insert_cell_above():
+    current_row, _ = vim.current.window.cursor
+    cell_boundaries = _get_cell_boundaries()
+    start_row, _ = _get_current_cell_boundaries(current_row,
+                                                      cell_boundaries)
+
+    header_row = start_row - 1
+    # Jump cursor to end_row
+    if header_row != current_row:
+        try:
+            vim.current.window.cursor = (header_row, 0)
+        except vim.error:
+            vim.command("echo 'Cell header is outside the buffer boundaries'")
+
+    # Insert tag above
+    insert_tag = vim.eval('g:ipython_insert_cell_tag')
+    vim.command("normal!O")
+    vim.command("normal!O" + insert_tag)
+    vim.command("normal!o")
+
+
 def previous_command():
     """Run previous command."""
     _slimesend(CTRL_P)

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -141,7 +141,6 @@ def insert_cell_below():
     if current_row != 1:
         vim.command("normal!o")
     vim.command("normal!i" + insert_tag)
-    vim.command("normal!o")
 
 
 def insert_cell_above():

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -148,7 +148,13 @@ def insert_cell_above():
     insert_tag = vim.eval('g:ipython_cell_insert_tag')
 
     current_row, _ = vim.current.window.cursor
-    cell_boundaries = _get_cell_boundaries()
+    cell_boundaries = _get_cell_boundaries(auto_include_first_line=False)
+
+    # Include first line of buffer if necessary
+    first_line_contains_cell_header = 1 in cell_boundaries
+    if not first_line_contains_cell_header:
+        cell_boundaries.insert(0, 1)
+
     start_row, _ = _get_current_cell_boundaries(current_row, cell_boundaries)
 
     # If the cursor not at the header of the current cell,
@@ -159,15 +165,15 @@ def insert_cell_above():
         except vim.error:
             vim.command("echo 'Cell header is outside the buffer boundaries'")
 
+    # If the start_row is the first line and not contains header
+    # We instert a cell header for the current cell
+    if start_row == 1 and not first_line_contains_cell_header:
+        vim.command("normal!O")
+        vim.command("normal!i" + insert_tag)
+
     vim.command("normal!O")
     vim.command("normal!O")
     vim.command("normal!i" + insert_tag)
-    current_row, _ = vim.current.window.cursor
-    if current_row != 1:
-        vim.command("normal!o")
-    else:
-        vim.command("normal!O")
-        vim.command("normal!O")
 
 
 def previous_command():

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -117,7 +117,7 @@ def jump_prev_cell():
 
 
 def insert_cell_below():
-    insert_tag = vim.eval('g:ipython_insert_cell_tag')
+    insert_tag = vim.eval('g:ipython_cell_insert_tag')
 
     current_row, _ = vim.current.window.cursor
     cell_boundaries = _get_cell_boundaries()
@@ -145,7 +145,7 @@ def insert_cell_below():
 
 
 def insert_cell_above():
-    insert_tag = vim.eval('g:ipython_insert_cell_tag')
+    insert_tag = vim.eval('g:ipython_cell_insert_tag')
 
     current_row, _ = vim.current.window.cursor
     cell_boundaries = _get_cell_boundaries()

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -140,7 +140,6 @@ def insert_cell_below():
     current_row, _ = vim.current.window.cursor
     if current_row != 1:
         vim.command("normal!o")
-    vim.command("normal!o")
     vim.command("normal!O")
     vim.command("normal!i" + insert_tag)
 

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -137,7 +137,7 @@ def insert_cell_below():
     # Insert tag bellow
     if vim.current.line != '':
         vim.command("normal!o")
-    current_row, _ = vim.current.cursor
+    current_row, _ = vim.current.window.cursor
     if current_row != 1:
         vim.command("normal!o")
     vim.command("normal!i" + insert_tag)

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -117,10 +117,11 @@ def jump_prev_cell():
 
 
 def insert_cell_below():
+    insert_tag = vim.eval('g:ipython_insert_cell_tag')
+
     current_row, _ = vim.current.window.cursor
     cell_boundaries = _get_cell_boundaries()
-    _, end_row = _get_current_cell_boundaries(current_row,
-                                                      cell_boundaries)
+    _, end_row = _get_current_cell_boundaries(current_row, cell_boundaries)
 
     # Required for Python 2
     if end_row is None:
@@ -134,31 +135,35 @@ def insert_cell_below():
             vim.command("echo 'Cell header is outside the buffer boundaries'")
 
     # Insert tag bellow
-    insert_tag = vim.eval('g:ipython_insert_cell_tag')
-    vim.command("normal!o")
-    vim.command("normal!o" + insert_tag)
+    if vim.current.line != '':
+        vim.command("normal!o")
+    current_row, _ = vim.current.cursor
+    if current_row != 1:
+        vim.command("normal!o")
+    vim.command("normal!i" + insert_tag)
     vim.command("normal!o")
 
 
 def insert_cell_above():
-    current_row, _ = vim.current.window.cursor
-    cell_boundaries = _get_cell_boundaries()
-    start_row, _ = _get_current_cell_boundaries(current_row,
-                                                      cell_boundaries)
-
-    header_row = start_row - 1
-    # Jump cursor to end_row
-    if header_row != current_row:
-        try:
-            vim.current.window.cursor = (header_row, 0)
-        except vim.error:
-            vim.command("echo 'Cell header is outside the buffer boundaries'")
-
-    # Insert tag above
     insert_tag = vim.eval('g:ipython_insert_cell_tag')
+
+    current_row, _ = vim.window.cursor
+    cell_boundaries = _get_cell_boundaries()
+    start_row, _ = _get_current_cell_boundaries(current_row, cell_boundaries)
+
+    # If the cursor not at the header of the current cell,
+    # we move the cursor to the header
+    if current_row != start_row:
+        jump_prev_cell()
     vim.command("normal!O")
-    vim.command("normal!O" + insert_tag)
-    vim.command("normal!o")
+    vim.command("normal!O")
+    vim.command("normal!i" + insert_tag)
+    current_row, _ = vim.window.cursor
+    if current_row != 1:
+        vim.command("normal!o")
+    else:
+        vim.command("normal!O")
+        vim.command("normal!O")
 
 
 def previous_command():

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -140,7 +140,9 @@ def insert_cell_below():
     current_row, _ = vim.current.window.cursor
     if current_row != 1:
         vim.command("normal!o")
-    vim.command("normal!O")
+        current_row += 1
+    if current_row != len(vim.current.buffer):
+        vim.command("normal!O")
     vim.command("normal!i" + insert_tag)
 
 

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -140,6 +140,8 @@ def insert_cell_below():
     current_row, _ = vim.current.window.cursor
     if current_row != 1:
         vim.command("normal!o")
+    vim.command("normal!o")
+    vim.command("normal!O")
     vim.command("normal!i" + insert_tag)
 
 


### PR DESCRIPTION
I added 2 commands: `IPythonCellInsertAbove` and `IPythonCellInsertBelow` insert a new cell above/below current cell.

The cell tag inserted can be specified via `g:ipython_cell_insert_tag` (defaults to `g:ipython_cell_tag[0]`).

Please take a look, and thanks for the amazing extension.

![insert_comamnds](https://user-images.githubusercontent.com/46804938/118133550-2ad30d00-b42b-11eb-8d31-e174f52c6772.gif)
