### PR TITLE
Add to IPythonCellToMarkdown

### DIFF
--- a/plugin/ipython-cell.vim
+++ b/plugin/ipython-cell.vim
@@ -112,6 +112,13 @@ command! -nargs=0 IPythonCellInsertBelow call IPythonCellInsertBelow()
 command! -nargs=0 IPythonCellInsertAbove call IPythonCellInsertAbove()
 command! -nargs=0 IPythonCellToMarkdown call IPythonCellToMarkdown()
 
+let s:ipython_cell_match_patterns = []
+for tag in g:ipython_cell_tag
+  add(s:ipython_cell_match_patterns, '\s*'. tag . '.*')
+endfor
+
+let g:ipython_cell_match_pattern = join(s:ipython_cell_match_patterns, '\|')
+
 highlight default link IPythonCell Folded
 function! UpdateCellHighlight()
     if g:ipython_cell_highlight_cells == 0
@@ -120,7 +127,7 @@ function! UpdateCellHighlight()
 
     if index(g:ipython_cell_highlight_cells_ft, &filetype) >= 0
         if !exists('w:ipython_cell_match')
-            let w:ipython_cell_match=matchadd('IPythonCell', '\s*# %%.*\|\s*#%%.*\|\s*# <codecell>.*\|\s*##.*')
+            let w:ipython_cell_match=matchadd('IPythonCell', g:ipython_cell_match_pattern)
         endif
     else
         if exists('w:ipython_cell_match')

--- a/plugin/ipython-cell.vim
+++ b/plugin/ipython-cell.vim
@@ -92,6 +92,10 @@ function! IPythonCellInsertAbove(...)
     exec s:python_command "ipython_cell.insert_cell_above()"
 endfunction
 
+function! IPythonCellToMarkdown(...)
+    exec s:python_command "ipython_cell.to_markdown()"
+endfunction
+
 command! -nargs=0 IPythonCellClear call IPythonCellClear()
 command! -nargs=0 IPythonCellClose call IPythonCellClose()
 command! -nargs=0 IPythonCellExecuteCell call IPythonCellExecuteCell()
@@ -106,6 +110,7 @@ command! -nargs=0 IPythonCellRun call IPythonCellRun()
 command! -nargs=0 IPythonCellRunTime call IPythonCellRun('-t')
 command! -nargs=0 IPythonCellInsertBelow call IPythonCellInsertBelow()
 command! -nargs=0 IPythonCellInsertAbove call IPythonCellInsertAbove()
+command! -nargs=0 IPythonCellToMarkdown call IPythonCellToMarkdown()
 
 highlight default link IPythonCell Folded
 function! UpdateCellHighlight()

--- a/plugin/ipython-cell.vim
+++ b/plugin/ipython-cell.vim
@@ -114,7 +114,7 @@ command! -nargs=0 IPythonCellToMarkdown call IPythonCellToMarkdown()
 
 let s:ipython_cell_match_patterns = []
 for tag in g:ipython_cell_tag
-  add(s:ipython_cell_match_patterns, '\s*'. tag . '.*')
+  call add(s:ipython_cell_match_patterns, '\s*'. tag . '.*')
 endfor
 
 let g:ipython_cell_match_pattern = join(s:ipython_cell_match_patterns, '\|')

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -205,7 +205,7 @@ def to_markdown():
     vim.command('normal!O')
     vim.command('normal!i"""')
 
-    vim.command("Current line after end insert: ", vim.current.line)
+    vim.command(f"echo 'Current line after move to start: {vim.current.line}'")
 
     # We move the cursor to the header
     if current_row != start_row:
@@ -214,8 +214,8 @@ def to_markdown():
         except vim.error:
             vim.command("echo 'Cell is outside the buffer boundaries'")
 
-    vim.command(f"Start idx: {start_row}, text: {vim.current.buffer[start_row-1]}")
-    vim.command("Current line after move to start: ", vim.current.line)
+    vim.command(f"echo 'Start idx: {start_row}, text: {vim.current.buffer[start_row-1]}'")
+    vim.command(f"echo 'Current line after move to start: {vim.current.line}'")
 
     # If the start_row is the first line and not contains header
     # We instert a cell header for the current cell

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -208,11 +208,10 @@ def to_markdown():
     vim.command(f"echo 'Current line after move to start: {vim.current.line}'")
 
     # We move the cursor to the header
-    if current_row != start_row:
-        try:
-            vim.current.window.cursor = (start_row, 0)
-        except vim.error:
-            vim.command("echo 'Cell is outside the buffer boundaries'")
+    try:
+        vim.current.window.cursor = (start_row, 0)
+    except vim.error:
+        vim.command("echo 'Cell is outside the buffer boundaries'")
 
     vim.command(f"echo 'Start idx: {start_row}, text: {vim.current.buffer[start_row-1]}'")
     vim.command(f"echo 'Current line after move to start: {vim.current.line}'")

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -203,7 +203,9 @@ def to_markdown():
     if vim.current.line != '':
         vim.command("normal!o")
 
-    vim.command('normal!O')
+    current_row, _ = vim.current.window.cursor
+    if current_row != len(vim.current.buffer):
+        vim.command('normal!O')
     vim.command('normal!i"""')
 
     # We move the cursor to the header

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -177,6 +177,44 @@ def insert_cell_above():
         vim.command("normal!O")
         vim.command("normal!i" + insert_tag)
 
+def to_markdown():
+    insert_tag = vim.eval('g:ipython_cell_insert_tag')
+
+    current_row, _ = vim.current.window.cursor
+    cell_boundaries = _get_cell_boundaries(auto_include_first_line=False)
+
+    # Include first line of buffer if necessary
+    first_line_contains_cell_header = 1 in cell_boundaries
+    if not first_line_contains_cell_header:
+        cell_boundaries.insert(0, 1)
+
+    start_row, end_row = _get_current_cell_boundaries(current_row, cell_boundaries)
+
+    # Switch to end_row first as start_row will not change after insert """ line
+    if current_row != end_row:
+        try:
+            vim.current.window.cursor = (end_row, 0)
+        except vim.error:
+            vim.command("echo 'Cell is outside the buffer boundaries'")
+    vim.command('normal!o"""')
+
+    # We move the cursor to the header
+    if current_row != start_row:
+        try:
+            vim.current.window.cursor = (start_row, 0)
+        except vim.error:
+            vim.command("echo 'Cell header is outside the buffer boundaries'")
+
+    # If the start_row is the first line and not contains header
+    # We instert a cell header for the current cell
+    if start_row == 1 and not first_line_contains_cell_header:
+        vim.command("normal!O")
+        vim.command("normal!i" + insert_tag)
+
+    # Now we at the header row
+    vim.command('normal!A [markdown]')
+    vim.command('normal!o"""')
+    vim.command('normal!o')
 
 def previous_command():
     """Run previous command."""

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -205,12 +205,17 @@ def to_markdown():
     vim.command('normal!O')
     vim.command('normal!i"""')
 
+    vim.command("Current line after end insert: ", vim.current.line)
+
     # We move the cursor to the header
     if current_row != start_row:
         try:
             vim.current.window.cursor = (start_row, 0)
         except vim.error:
             vim.command("echo 'Cell is outside the buffer boundaries'")
+
+    vim.command(f"Start idx: {start_row}, text: {vim.current.buffer[start_row-1]}")
+    vim.command("Current line after move to start: ", vim.current.line)
 
     # If the start_row is the first line and not contains header
     # We instert a cell header for the current cell

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -189,6 +189,7 @@ def to_markdown():
         cell_boundaries.insert(0, 1)
 
     start_row, end_row = _get_current_cell_boundaries(current_row, cell_boundaries)
+    vim.command(f"echo 'start_row: {start_row}, end_row: {end_row}'")
 
     # Switch to end_row first as start_row will not change after insert """ line
     if current_row != end_row:

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -189,6 +189,8 @@ def to_markdown():
         cell_boundaries.insert(0, 1)
 
     start_row, end_row = _get_current_cell_boundaries(current_row, cell_boundaries)
+    vim.command("echo 'start_row: " + start_row + ", end_row: ", "end_row", "'")
+    vim.command("echo 'start_row text: " + vim.current.buffer[start_row-1] + ", end_row text: " + vim.current.buffer[end_row - 1] + "'")
 
     # Switch to end_row first as start_row will not change after insert """ line
     if current_row != end_row:
@@ -208,7 +210,7 @@ def to_markdown():
         try:
             vim.current.window.cursor = (start_row, 0)
         except vim.error:
-            vim.command("echo 'Cell header is outside the buffer boundaries'")
+            vim.command("echo 'Cell is outside the buffer boundaries'")
 
     # If the start_row is the first line and not contains header
     # We instert a cell header for the current cell

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -189,7 +189,7 @@ def to_markdown():
         cell_boundaries.insert(0, 1)
 
     start_row, end_row = _get_current_cell_boundaries(current_row, cell_boundaries)
-    vim.command("echo 'start_row: " + start_row + ", end_row: ", "end_row", "'")
+    vim.command("echo 'start_row: " + str(start_row) + ", end_row: " + str(end_row) + "'")
     vim.command("echo 'start_row text: " + vim.current.buffer[start_row-1] + ", end_row text: " + vim.current.buffer[end_row - 1] + "'")
 
     # Switch to end_row first as start_row will not change after insert """ line

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -196,7 +196,12 @@ def to_markdown():
             vim.current.window.cursor = (end_row, 0)
         except vim.error:
             vim.command("echo 'Cell is outside the buffer boundaries'")
-    vim.command('normal!o"""')
+
+    if vim.current.line != '':
+        vim.command("normal!o")
+
+    vim.command('normal!O')
+    vim.command('normal!i"""')
 
     # We move the cursor to the header
     if current_row != start_row:
@@ -213,8 +218,9 @@ def to_markdown():
 
     # Now we at the header row
     vim.command('normal!A [markdown]')
-    vim.command('normal!o"""')
     vim.command('normal!o')
+    vim.command('normal!i"""')
+    vim.command('normal!j')
 
 def previous_command():
     """Run previous command."""

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -189,8 +189,6 @@ def to_markdown():
         cell_boundaries.insert(0, 1)
 
     start_row, end_row = _get_current_cell_boundaries(current_row, cell_boundaries)
-    vim.command("echo 'start_row: " + str(start_row) + ", end_row: " + str(end_row) + "'")
-    vim.command("echo 'start_row text: " + vim.current.buffer[start_row-1] + ", end_row text: " + vim.current.buffer[end_row - 1] + "'")
 
     # Switch to end_row first as start_row will not change after insert """ line
     if current_row != end_row:
@@ -205,16 +203,11 @@ def to_markdown():
     vim.command('normal!O')
     vim.command('normal!i"""')
 
-    vim.command(f"echo 'Current line after move to start: {vim.current.line}'")
-
     # We move the cursor to the header
     try:
         vim.current.window.cursor = (start_row, 0)
     except vim.error:
         vim.command("echo 'Cell is outside the buffer boundaries'")
-
-    vim.command(f"echo 'Start idx: {start_row}, text: {vim.current.buffer[start_row-1]}'")
-    vim.command(f"echo 'Current line after move to start: {vim.current.line}'")
 
     # If the start_row is the first line and not contains header
     # We instert a cell header for the current cell

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -189,7 +189,9 @@ def to_markdown():
         cell_boundaries.insert(0, 1)
 
     start_row, end_row = _get_current_cell_boundaries(current_row, cell_boundaries)
-    vim.command(f"echo 'start_row: {start_row}, end_row: {end_row}'")
+
+    if end_row is None:
+        end_row = len(vim.current.buffer)
 
     # Switch to end_row first as start_row will not change after insert """ line
     if current_row != end_row:


### PR DESCRIPTION
Hi, I'm using [jupytext](https://github.com/mwouts/jupytext) to open .ipynb as a .py file and edit them, so I want a quick command to turn a current cell into a markdown cell compatible with jupytext provided format.

**What changed?**
- Added an `IPythonCellToMarkdown` command to turn the current cell into a markdown cell.
- Only highlight the headers specified by `g:ipython_cell_tag` (I personally removed `##` from the header list as it will conflict with markdown syntax)

Demo:
![ipython_cell_to_markdown](https://user-images.githubusercontent.com/46804938/119330287-41d9f080-bcb0-11eb-825f-b99741f670a1.gif)