### PR TITLE
Allow configuration of 'restart' function

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Configuration
 | `g:ipython_cell_send_ctrl_c`          | Send `i` and Ctrl-C to enter insert mode and clear the prompt before sending commands to IPython. Set to `0` if this is not supported by your shell. Default: `1`                   |
 | `g:ipython_cell_send_ctrl_u`          | Send Ctrl-U to clear the line before sending commands to IPython. Default: `0`                                                                                                      |
 | `g:ipython_cell_update_file_variable` | Set to `1` to update the `__file__` variable in IPython when running cells. Default: `0`                                                                                            |
-| `g:ipython_cell_shell_prev_cmd`       | The preferred way to get the previous command in your shell. As the variable value, you can provide `'!!'`, `'fc -e: -1'`, or `''`. The latter corresponds to `Ctrl-P`. Default: `Ctrl-P` |
+| `g:ipython_cell_shell_prev_cmd`       | The preferred way to get the previous command in your shell. As the variable value, you can provide `'!!'`, `'fc -e: -1'`, or `'<C-p>'` (case-insensitive). The latter corresponds to sending to the console [`\x10`](https://condor.depaul.edu/sjost/lsp121/documents/ascii-npr.htm). Default: `'!!'` |
 
 
 <sup>1</sup> `{options}` will be replaced by the command options, such as `-t` for `IPythonRunTime`. `{filepath}` will be replaced by the path of the current buffer.
@@ -336,6 +336,7 @@ let g:slime_python_ipython = 1
 let g:slime_default_config = {
             \ 'socket_name': get(split($TMUX, ','), 0),
             \ 'target_pane': '{top-right}' }
+
 let g:slime_dont_ask_default = 1
 
 "------------------------------------------------------------------------------
@@ -602,9 +603,13 @@ Try to add the following to your configuration file:
 > The restart command `IPythonCellRestart` does not work. It terminates an
 > IPython session instead of restarting the kernel.
 
-Try to add the following to your configuration file:
+Try to change the way you get the previous command in your shell. For example,
 
-    let g:ipython_cell_shell_prev_cmd = '!!'
+    "" Substitute '<C-p>' for '!!'.
+    let g:ipython_cell_shell_prev_cmd = '<C-p>'
+    "" The following is also valid:
+    " let g:ipython_cell_shell_prev_cmd = '<Ctrl-P>'
+
 
 Related plugins
 ---------------

--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ Configuration
 | `g:ipython_cell_send_ctrl_c`          | Send `i` and Ctrl-C to enter insert mode and clear the prompt before sending commands to IPython. Set to `0` if this is not supported by your shell. Default: `1`                   |
 | `g:ipython_cell_send_ctrl_u`          | Send Ctrl-U to clear the line before sending commands to IPython. Default: `0`                                                                                                      |
 | `g:ipython_cell_update_file_variable` | Set to `1` to update the `__file__` variable in IPython when running cells. Default: `0`                                                                                            |
+| `g:ipython_cell_shell_prev_cmd`       | The preferred way to get the previous command in your shell. As the variable value, you can provide `'!!'`, `'fc -e: -1'`, or `''`. The latter corresponds to `Ctrl-P`. Default: `Ctrl-P` |
+
 
 <sup>1</sup> `{options}` will be replaced by the command options, such as `-t` for `IPythonRunTime`. `{filepath}` will be replaced by the path of the current buffer.
 
@@ -597,6 +599,12 @@ Try to add the following to your configuration file:
 
     let g:ipython_cell_send_ctrl_u = 0
 
+> The restart command `IPythonCellRestart` does not work. It terminates an
+> IPython session instead of restarting the kernel.
+
+Try to add the following to your configuration file:
+
+    let g:ipython_cell_shell_prev_cmd = '!!'
 
 Related plugins
 ---------------

--- a/doc/ipython-cell.txt
+++ b/doc/ipython-cell.txt
@@ -195,9 +195,11 @@ g:ipython_cell_update_file_variable  Set to `1` to update the `__file__`
                                                  *ipython-cell-shell-prev_cmd*
 g:ipython_cell_shell_prev_cmd        The preferred way to get the previous
                                      command in your shell. As the variable
-                                     value, you can provide `'!!'`, `'fc -e:
-                                     -1'`, or `''`. The latter corresponds to
-                                     `Ctrl-P`. Default: `Ctrl-P`
+                                     value, you can provide `'!!'`, `'fc -e: -1'`,
+                                     or `<C-p>` (case-insensitive). The latter
+                                     corresponds to sending to the console the
+                                     ASCII char `\x10`.
+                                     Default: `'!!'`
 
                                                 *ipython-cell-highlight-group*
 By default, cell headers defined using tags are highlighted using the
@@ -298,9 +300,13 @@ A:Try to add the following to your configuration file:
 Q: The restart command `IPythonCellRestart` does not work. It terminates an
 IPython session instead of restarting the kernel.
 
-A: Try to add the following to your configuration file:
+A: Try to change the way you get the previous command in your shell. For
+example,
 
-    let g:ipython_cell_shell_prev_cmd = '!!'
+    "" Substitute '<C-p>' for '!!'.
+    let g:ipython_cell_shell_prev_cmd = '<C-p>'
+    "" The following is also valid:
+    " let g:ipython_cell_shell_prev_cmd = '<Ctrl-P>'
 
 ==============================================================================
 ABOUT                                                     *ipython-cell-about*

--- a/doc/ipython-cell.txt
+++ b/doc/ipython-cell.txt
@@ -192,6 +192,13 @@ g:ipython_cell_update_file_variable  Set to `1` to update the `__file__`
                                      variable in IPython when running cells.
                                      Default: `0`
 
+                                                 *ipython-cell-shell-prev_cmd*
+g:ipython_cell_shell_prev_cmd        The preferred way to get the previous
+                                     command in your shell. As the variable
+                                     value, you can provide `'!!'`, `'fc -e:
+                                     -1'`, or `''`. The latter corresponds to
+                                     `Ctrl-P`. Default: `Ctrl-P`
+
                                                 *ipython-cell-highlight-group*
 By default, cell headers defined using tags are highlighted using the
 `IPythonCell` highlight group.
@@ -284,9 +291,16 @@ version, I would be happy to consider to merge it.
 Q: I get an error (e.g. SyntaxError) because the plugin inserts `^U` before ~
 the command, what should I do? ~
 
-Try to add the following to your configuration file:
+A:Try to add the following to your configuration file:
 
     let g:ipython_cell_send_ctrl_u = 0
+
+Q: The restart command `IPythonCellRestart` does not work. It terminates an
+IPython session instead of restarting the kernel.
+
+A: Try to add the following to your configuration file:
+
+    let g:ipython_cell_shell_prev_cmd = '!!'
 
 ==============================================================================
 ABOUT                                                     *ipython-cell-about*

--- a/plugin/ipython-cell.vim
+++ b/plugin/ipython-cell.vim
@@ -12,6 +12,7 @@ if !has("python") && !has("python3")
     finish
 endif
 
+let g:ipython_cell_shell_prev_cmd = get(g:, 'ipython_cell_shell_prev_cmd', '')
 let g:ipython_cell_delimit_cells_by = get(g:, 'ipython_cell_delimit_cells_by', 'tags')
 let g:ipython_cell_tag = get(g:, 'ipython_cell_tag', ['# %%', '#%%', '# <codecell>', '##'])
 let g:ipython_cell_insert_tag = get(g:, 'ipython_cell_insert_tag', '# %% ')
@@ -80,7 +81,7 @@ function! IPythonCellPrevCommand()
 endfunction
 
 function! IPythonCellRestart()
-    exec s:python_command "ipython_cell.restart_ipython()"
+    exec s:python_command "ipython_cell.restart_ipython('".g:ipython_cell_shell_prev_cmd."')"
 endfunction
 
 function! IPythonCellRun(...)

--- a/plugin/ipython-cell.vim
+++ b/plugin/ipython-cell.vim
@@ -12,7 +12,6 @@ if !has("python") && !has("python3")
     finish
 endif
 
-let g:ipython_cell_shell_prev_cmd = get(g:, 'ipython_cell_shell_prev_cmd', '')
 let g:ipython_cell_delimit_cells_by = get(g:, 'ipython_cell_delimit_cells_by', 'tags')
 let g:ipython_cell_tag = get(g:, 'ipython_cell_tag', ['# %%', '#%%', '# <codecell>', '##'])
 let g:ipython_cell_insert_tag = get(g:, 'ipython_cell_insert_tag', '# %% ')
@@ -27,6 +26,7 @@ let g:ipython_cell_send_cell_headers = get(g:, 'ipython_cell_send_cell_headers',
 let g:ipython_cell_send_ctrl_c = get(g:, 'ipython_cell_send_ctrl_c', 1)
 let g:ipython_cell_send_ctrl_u = get(g:, 'ipython_cell_send_ctrl_u', 0)
 let g:ipython_cell_update_file_variable = get(g:, 'ipython_cell_update_file_variable', 0)
+let g:ipython_cell_shell_prev_cmd = get(g:, 'ipython_cell_shell_prev_cmd', '!!')
 
 function! s:UsingPython3()
   if has('python3')
@@ -81,7 +81,7 @@ function! IPythonCellPrevCommand()
 endfunction
 
 function! IPythonCellRestart()
-    exec s:python_command "ipython_cell.restart_ipython('".g:ipython_cell_shell_prev_cmd."')"
+    exec s:python_command "ipython_cell.restart_ipython('" . g:ipython_cell_shell_prev_cmd . "')"
 endfunction
 
 function! IPythonCellRun(...)

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -246,8 +246,11 @@ def previous_command():
     _slimesend(CTRL_P)
 
 
-def restart_ipython(shell_prev_cmd=CTRL_P):
+def restart_ipython(shell_prev_cmd):
     """Quit ipython and start it again."""
+    if shell_prev_cmd.upper() in ('<C-P>', '<CTRL-P>'):
+        shell_prev_cmd = CTRL_P
+
     _clear_prompt()
     _slimesend("exit")
     _slimesend(shell_prev_cmd)

--- a/python/ipython_cell.py
+++ b/python/ipython_cell.py
@@ -246,11 +246,11 @@ def previous_command():
     _slimesend(CTRL_P)
 
 
-def restart_ipython():
+def restart_ipython(shell_prev_cmd=CTRL_P):
     """Quit ipython and start it again."""
     _clear_prompt()
     _slimesend("exit")
-    _slimesend(CTRL_P)
+    _slimesend(shell_prev_cmd)
 
 
 def run(*args):


### PR DESCRIPTION
Hi! I've encountered a problem with your plugin that `IPythonCellRestart` just terminates IPython session instead of restarting it.
This is because executing the previous shell command with Ctrl-P doesn't work for all shells. For me, it might be not working due to using Vi mode instead of Emacs in the shell cmdline.

IMO, it is a common practice that users customize their shells and Jupyter Notebook configurations, but do not change settings of IPython, a console app. If there is no a general solution (that accounts for different shells), it may be a good decision to allow a user to specify the command they use to get the previous shell command.

NOTE: I did not align the markdown table I edited in README, since it would lead to displaying meaningless changes in git diff.